### PR TITLE
Introduce new KMP targets for better structure

### DIFF
--- a/eungabi/build.gradle.kts
+++ b/eungabi/build.gradle.kts
@@ -58,11 +58,72 @@ kotlin {
     }
 
     sourceSets {
+        val commonMain by getting
+
+        val jvmMain by creating {
+            dependsOn(commonMain)
+        }
+
+        val desktopMain by getting {
+            dependsOn(jvmMain)
+        }
+
+        val nonJvmMain by creating {
+            dependsOn(commonMain)
+        }
+
+        val webMain by creating {
+            dependsOn(nonJvmMain)
+        }
+
+        val appleMain by creating {
+            dependsOn(nonJvmMain)
+        }
+
+        val iosMain by creating {
+            dependsOn(appleMain)
+        }
+
+        val macOsMain by creating {
+            dependsOn(appleMain)
+        }
+
+        val iosArm64Main by getting {
+            dependsOn(iosMain)
+        }
+
+        val iosX64Main by getting {
+            dependsOn(iosMain)
+        }
+
+        val iosSimulatorArm64Main by getting {
+            dependsOn(iosMain)
+        }
+
+        val macosArm64Main by getting {
+            dependsOn(macOsMain)
+        }
+
+        val macosX64Main by getting {
+            dependsOn(macOsMain)
+        }
+
+        jsMain {
+            dependsOn(webMain)
+        }
+
+        wasmJsMain {
+            dependsOn(webMain)
+        }
+
         val desktopTest by getting
 
-        androidMain.dependencies {
-            implementation(libs.androidx.activity.compose)
-            implementation(libs.androidx.core.ktx)
+        androidMain {
+            dependsOn(jvmMain)
+            dependencies {
+                implementation(libs.androidx.activity.compose)
+                implementation(libs.androidx.core.ktx)
+            }
         }
         commonMain.dependencies {
             implementation(compose.ui)
@@ -83,7 +144,6 @@ kotlin {
             @OptIn(ExperimentalComposeLibrary::class)
             implementation(compose.uiTest)
         }
-
         desktopTest.dependencies {
             implementation(compose.desktop.currentOs)
         }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/6fe92de7-7085-45f0-886b-fb0d32c1f49e)


This commit introduces new KMP targets to improve project structure:
- JvmMain: Combines Android and Desktop targets.
- nonJvmMain: For non-JVM targets.
- AppleMain: For macOS and iOS targets.

This refactoring simplifies the project structure and improves maintainability.